### PR TITLE
mongoRepository, mysqlRepository 인식 config 추가

### DIFF
--- a/src/main/java/hobbiedo/crew/application/ChatServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/ChatServiceImp.java
@@ -20,7 +20,7 @@ import hobbiedo.crew.dto.response.ChatImageDTO;
 import hobbiedo.crew.dto.response.ChatImageListDTO;
 import hobbiedo.crew.global.exception.GlobalException;
 import hobbiedo.crew.global.status.ErrorStatus;
-import hobbiedo.crew.infrastructure.ChatRepository;
+import hobbiedo.crew.mongoInfrastructure.ChatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/hobbiedo/crew/global/config/JpaConfig.java
+++ b/src/main/java/hobbiedo/crew/global/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package hobbiedo.crew.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "hobbiedo.crew.mysqlInfrastructure")
+public class JpaConfig {
+}

--- a/src/main/java/hobbiedo/crew/global/config/MongoDbConfig.java
+++ b/src/main/java/hobbiedo/crew/global/config/MongoDbConfig.java
@@ -1,0 +1,33 @@
+package hobbiedo.crew.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableMongoAuditing
+@EnableMongoRepositories(basePackages = "hobbiedo.crew.mongoInfrastructure")
+public class MongoDbConfig {
+
+	private final MongoMappingContext mongoMappingContext;
+
+	@Bean
+	public MappingMongoConverter mappingMongoConverter(MongoDatabaseFactory mongoDatabaseFactory,
+		MongoMappingContext mongoMappingContext) {
+		DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDatabaseFactory);
+		MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver,
+			mongoMappingContext);
+		converter.setTypeMapper(new DefaultMongoTypeMapper(null));
+		return converter;
+	}
+}

--- a/src/main/java/hobbiedo/crew/mongoInfrastructure/ChatRepository.java
+++ b/src/main/java/hobbiedo/crew/mongoInfrastructure/ChatRepository.java
@@ -1,4 +1,4 @@
-package hobbiedo.crew.infrastructure;
+package hobbiedo.crew.mongoInfrastructure;
 
 import java.time.Instant;
 import java.util.List;


### PR DESCRIPTION
## 📣 mongoRepository, mysqlRepository 인식 config 추가
### 📅 20204.06.03

### 🌵Branch
feature/chat  → develop

### 📢 Description
한 레파지토리에서 두 가지 DB를 쓰기 위해, mongoRepository, mysqlRepository 인식 config 추가했다.

### 💬Issue Number
[#1 ] - 채팅 이전내역 조회, 사진 모아보기 구현

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)