### PR TITLE
채팅 이전 내역 조회, 사진 모아보기 정렬 및 기간 변경

### DIFF
--- a/src/main/java/hobbiedo/crew/application/ChatService.java
+++ b/src/main/java/hobbiedo/crew/application/ChatService.java
@@ -3,14 +3,11 @@ package hobbiedo.crew.application;
 import java.time.Instant;
 import java.util.List;
 
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.transaction.annotation.Transactional;
-
 import hobbiedo.crew.dto.response.ChatHistoryListDTO;
 import hobbiedo.crew.dto.response.ChatImageListDTO;
 
 public interface ChatService {
-	List<ChatHistoryListDTO> getChatHistorySince(Long crewId, Instant since);
+	List<ChatHistoryListDTO> getChatHistoryBefore(Long crewId, Instant oldestChatTime);
 
 	List<ChatImageListDTO> getChatsWithImageUrl(Long crewId);
 

--- a/src/main/java/hobbiedo/crew/application/ChatService.java
+++ b/src/main/java/hobbiedo/crew/application/ChatService.java
@@ -1,13 +1,13 @@
 package hobbiedo.crew.application;
 
-import java.time.Instant;
 import java.util.List;
 
 import hobbiedo.crew.dto.response.ChatHistoryListDTO;
 import hobbiedo.crew.dto.response.ChatImageListDTO;
 
 public interface ChatService {
-	List<ChatHistoryListDTO> getChatHistoryBefore(Long crewId, Instant oldestChatTime);
+
+	List<ChatHistoryListDTO> getChatHistoryBefore(Long crewId, int page);
 
 	List<ChatImageListDTO> getChatsWithImageUrl(Long crewId);
 

--- a/src/main/java/hobbiedo/crew/application/ChatServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/ChatServiceImp.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -68,6 +69,7 @@ public class ChatServiceImp implements ChatService {
 			.map(entry -> {
 				List<ChatImageDTO> chatImageDTOList = entry.getValue().stream()
 					.map(ChatImageDTO::toDto)
+					.sorted(Comparator.comparing(ChatImageDTO::getCreatedAt).reversed())
 					.toList();
 				return ChatImageListDTO.toDto(entry.getKey(), chatImageDTOList);
 			})

--- a/src/main/java/hobbiedo/crew/global/config/SwaggerConfig.java
+++ b/src/main/java/hobbiedo/crew/global/config/SwaggerConfig.java
@@ -20,8 +20,8 @@ public class SwaggerConfig {
 	public OpenAPI openApi() {
 		return new OpenAPI().components(new Components())
 			.addSecurityItem(new SecurityRequirement().addList(BEARER_TOKEN))
-			.addServersItem(new Server().url("/"))
 			.addServersItem(new Server().url("/crew-service"))
+			.addServersItem(new Server().url("/"))
 			.components(new Components().addSecuritySchemes(BEARER_TOKEN,
 				new SecurityScheme().name(BEARER_TOKEN)
 					.type(SecurityScheme.Type.HTTP)

--- a/src/main/java/hobbiedo/crew/global/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/crew/global/status/ErrorStatus.java
@@ -10,7 +10,8 @@ public enum ErrorStatus {
 	INTERNAL_SERVER_ERROR("SERVER500", "Internal server error"),
 	BAD_REQUEST("REQUEST400", "Bad request"),
 
-	NO_EXIST_IMAGE_CHAT("CHAT401", "조회 가능한 사진 체팅이 존재하지 않습니다.");
+	NO_EXIST_IMAGE_CHAT("CHAT401", "조회 가능한 사진 체팅이 존재하지 않습니다."),
+	NO_EXIST_CHAT("CHAT406", "조회 가능한 체팅이 존재하지 않습니다.");
 
 	private final String status;
 	private final String message;

--- a/src/main/java/hobbiedo/crew/mongoInfrastructure/ChatRepository.java
+++ b/src/main/java/hobbiedo/crew/mongoInfrastructure/ChatRepository.java
@@ -3,17 +3,17 @@ package hobbiedo.crew.mongoInfrastructure;
 import java.time.Instant;
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import hobbiedo.crew.domain.Chat;
 
 public interface ChatRepository extends MongoRepository<Chat, String> {
-	@Query("{ 'crewId': ?0, 'createdAt': { '$gt': ?1, '$lt': ?2 } }")
-	List<Chat> findByCrewIdAndCreatedAtBetween(Long crewId, Instant start, Instant end);
+	List<Chat> findByCrewId(Long crewId, Pageable pageable);
 
 	@Query("{ 'crewId': ?0, 'imageUrl': { '$exists': true } }")
-	List<Chat> findByCrewIdAndImageUrlExists(Long crewId);
+	List<Chat> findByCrewIdAndImageUrl(Long crewId);
 
 	@Query(value = "{ 'imageUrl': { '$exists': true }, 'createdAt': { '$lt': ?0 } }", delete = true)
 	void deleteByImageUrlExistsAndCreatedAtBefore(Instant expiryDate);

--- a/src/main/java/hobbiedo/crew/presentation/ChatController.java
+++ b/src/main/java/hobbiedo/crew/presentation/ChatController.java
@@ -25,12 +25,12 @@ import lombok.RequiredArgsConstructor;
 public class ChatController {
 	private final ChatService chatService;
 
-	@Operation(summary = "(특정 소모임의) 이전 채팅 내역 조회", description = "특정 시간 다음날 0시부터 7일간의 채팅 내역을 조회한다.")
+	@Operation(summary = "(특정 소모임의) 이전 채팅 내역 조회", description = "특정 시간 전날 0시부터 7일간의 이전 채팅 내역을 조회한다.")
 	@GetMapping("/history/{crewId}")
-	public BaseResponse<List<ChatHistoryListDTO>> getChatHistorySince(@PathVariable Long crewId,
-		@RequestParam Instant since) {
+	public BaseResponse<List<ChatHistoryListDTO>> getChatHistoryBefore(@PathVariable Long crewId,
+		@RequestParam Instant oldestChatTime) {
 		return BaseResponse.onSuccess(SuccessStatus.FIND_CHAT_HISTORY,
-			chatService.getChatHistorySince(crewId, since));
+			chatService.getChatHistoryBefore(crewId, oldestChatTime));
 	}
 
 	@Operation(summary = "(특정 소모임) 사진 모아보기", description = "특정 소모임의 이미지 URL이 있는 채팅 내역을 조회한다.")

--- a/src/main/java/hobbiedo/crew/presentation/ChatController.java
+++ b/src/main/java/hobbiedo/crew/presentation/ChatController.java
@@ -1,6 +1,5 @@
 package hobbiedo.crew.presentation;
 
-import java.time.Instant;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,12 +24,12 @@ import lombok.RequiredArgsConstructor;
 public class ChatController {
 	private final ChatService chatService;
 
-	@Operation(summary = "(특정 소모임의) 이전 채팅 내역 조회", description = "특정 시간 전날 0시부터 7일간의 이전 채팅 내역을 조회한다.")
+	@Operation(summary = "(특정 소모임의) 이전 채팅 내역 조회", description = "페이지에 따른 10개의 이전 채팅 내역을 조회한다.")
 	@GetMapping("/history/{crewId}")
 	public BaseResponse<List<ChatHistoryListDTO>> getChatHistoryBefore(@PathVariable Long crewId,
-		@RequestParam Instant oldestChatTime) {
+		@RequestParam int page) {
 		return BaseResponse.onSuccess(SuccessStatus.FIND_CHAT_HISTORY,
-			chatService.getChatHistoryBefore(crewId, oldestChatTime));
+			chatService.getChatHistoryBefore(crewId, page));
 	}
 
 	@Operation(summary = "(특정 소모임) 사진 모아보기", description = "특정 소모임의 이미지 URL이 있는 채팅 내역을 조회한다.")


### PR DESCRIPTION
## 📣 채팅 이전 내역 조회, 사진 모아보기 정렬 및 조회 기준 변경
### 📅 2024.06.04

### 🌵Branch
feature/chat  → develop

### 📢 Description
채팅 이전 내역 조회 - 페이지에 따른 조회(chat 10개씩), 정렬을 오래된 순으로 변경
사진 모아보기 - 최신순으로 변경

### 💬Issue Number
[#1 ] - 채팅 이전 내역 조회, 사진 모아보기 기능 구현

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
