### PR TITLE
취미와 활동 지역에 해당하는 소모임 정보 목록 조회 api 병합

### DIFF
--- a/src/main/java/hobbiedo/crew/application/CrewService.java
+++ b/src/main/java/hobbiedo/crew/application/CrewService.java
@@ -19,6 +19,8 @@ public interface CrewService {
 
 	void joinCrewMember(Crew crew, String uuid);
 
+	List<CrewDetailDTO> getCrewInfoList(long hobbyId, long regionId);
+
 	CrewDetailDTO getCrewInfo(Long crewId);
 
 	List<CrewIdDTO> getCrewsByHobbyAndRegion(long hobbyId, long regionId);

--- a/src/main/java/hobbiedo/crew/application/CrewServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/CrewServiceImp.java
@@ -129,6 +129,14 @@ public class CrewServiceImp implements CrewService {
 	}
 
 	@Override
+	public List<CrewDetailDTO> getCrewInfoList(long hobbyId, long regionId) {
+		List<CrewIdDTO> crewIds = getCrewsByHobbyAndRegion(hobbyId, regionId);
+		return crewIds.stream()
+			.map(crewId -> getCrewInfo(crewId.getCrewId()))
+			.toList();
+	}
+
+	@Override
 	public CrewDetailDTO getCrewInfo(Long crewId) {
 		Crew crew = getCrewById(crewId);
 

--- a/src/main/java/hobbiedo/crew/dto/response/CrewDetailDTO.java
+++ b/src/main/java/hobbiedo/crew/dto/response/CrewDetailDTO.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CrewDetailDTO {
+	private long crewId;
 	private String crewName;
 	private String addressName;
 	private String introduction;
@@ -19,6 +20,7 @@ public class CrewDetailDTO {
 
 	public static CrewDetailDTO toDto(Crew crew, String addressName, List<String> hashTagList) {
 		return CrewDetailDTO.builder()
+			.crewId(crew.getId())
 			.crewName(crew.getName())
 			.addressName(addressName)
 			.introduction(crew.getIntroduction())

--- a/src/main/java/hobbiedo/crew/presentation/CrewController.java
+++ b/src/main/java/hobbiedo/crew/presentation/CrewController.java
@@ -6,16 +6,20 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import hobbiedo.crew.application.JoinFormService;
-import hobbiedo.crew.dto.request.JoinFormRequestDTO;
-import hobbiedo.crew.dto.response.JoinFormListDTO;
-import hobbiedo.crew.dto.response.JoinFormResponseDTO;
-import hobbiedo.crew.dto.response.MyJoinFormDTO;
+import hobbiedo.crew.application.CrewService;
+import hobbiedo.crew.dto.request.CrewOutDTO;
+import hobbiedo.crew.dto.request.CrewRequestDTO;
+import hobbiedo.crew.dto.response.CrewDetailDTO;
+import hobbiedo.crew.dto.response.CrewIdDTO;
+import hobbiedo.crew.dto.response.CrewNameDTO;
+import hobbiedo.crew.dto.response.CrewProfileDTO;
+import hobbiedo.crew.dto.response.CrewResponseDTO;
 import hobbiedo.global.base.BaseResponse;
 import hobbiedo.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,61 +33,85 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v1/users/crew")
 public class CrewController {
 
-	private final JoinFormService joinFormService;
+	private final CrewService crewService;
 
-	@Operation(summary = "(가입 방식) 소모임 가입 신청서 제출", description = "가입 방식 소모임에 가입 신청서를 제출한다.")
-	@PostMapping("/submission/join-form/{crewId}")
-	public BaseResponse<Void> submissionJoinForm(@Valid @RequestBody JoinFormRequestDTO joinFormDTO,
+	@Operation(summary = "소모임 생성", description = "소모임을 생성한다.(대표 사진은 아예 안보내도 되고 해시태그는 []로, 있으면 5개까지 가능")
+	@PostMapping
+	public BaseResponse<CrewIdDTO> createCrew(@Valid @RequestBody CrewRequestDTO crewDTO,
+		@RequestHeader(name = "Uuid") String uuid) {
+		return BaseResponse.onSuccess(SuccessStatus.CREATE_CREW,
+			crewService.createCrew(crewDTO, uuid));
+	}
+
+	@Operation(summary = "(자유 방식) 소모임 가입", description = "자유 방식 소모임에 새로운 회원을 추가한다.")
+	@PostMapping("/join/{crewId}")
+	public BaseResponse<Void> joinFreeCrew(@PathVariable long crewId,
+		@RequestHeader(name = "Uuid") String uuid) {
+		crewService.joinCrew(crewId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.JOIN_FREE_CREW, null);
+	}
+
+	@Operation(summary = "소모임 정보 조회", description = "소모임 ID를 통해 소모임 정보를 조회한다.")
+	@GetMapping("/{crewId}")
+	public BaseResponse<CrewDetailDTO> getCrewInfo(@PathVariable long crewId) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_INFO,
+			crewService.getCrewInfo(crewId));
+	}
+
+	@Operation(summary = "취미와 활동 지역에 해당하는 소모임 아이디 조회", description = "취미와 활동 지역에 해당하는 소모임 아이디 리스트를 조회한다.(순서 랜덤)")
+	@GetMapping("/list/{hobbyId}/{regionId}")
+	public BaseResponse<List<CrewIdDTO>> getCrewIdList(@PathVariable long hobbyId,
+		@PathVariable long regionId) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_CREWS_BY_HOBBY_AND_REGION,
+			crewService.getCrewsByHobbyAndRegion(hobbyId, regionId));
+	}
+
+	@Operation(summary = "한 유저가 가입한 소모임 프로필 목록 조회", description = "한 유저가 가입한 소모임 프로필 목록을 조회한다.")
+	@GetMapping("/list/profile")
+	public BaseResponse<List<CrewProfileDTO>> getCrewProfileList(
+		@RequestHeader(name = "Uuid") String uuid) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_PROFILE_LIST,
+			crewService.getCrewProfiles(uuid));
+	}
+
+	@Operation(summary = "소모임 이름 조회", description = "소모임 ID를 통해 소모임 이름을 조회한다.")
+	@GetMapping("/name/{crewId}")
+	public BaseResponse<CrewNameDTO> getCrewName(@PathVariable long crewId) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_NAME,
+			crewService.getCrewName(crewId));
+	}
+
+	@Operation(summary = "소모임 탈퇴", description = "소모임에서 회원을 탈퇴시키고 소모임 인원을 -1 한다.")
+	@DeleteMapping("/withdrawal/{crewId}")
+	public BaseResponse<Void> withdrawalCrew(@PathVariable long crewId,
+		@RequestHeader(name = "Uuid") String uuid) {
+		crewService.deleteCrewMember(crewId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.WITHDRAWAL_CREW, null);
+	}
+
+	@Operation(summary = "소모임 정보 수정화면 조회", description = "소모임 정보 수정화면을 조회한다.")
+	@GetMapping("/modify-view/{crewId}")
+	public BaseResponse<CrewResponseDTO> getCrewModifyView(@PathVariable long crewId) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_MODIFY_VIEW,
+			crewService.getCrew(crewId));
+	}
+
+	@Operation(summary = "소모임 정보 수정", description = "소모임 정보를 수정한다.")
+	@PutMapping("/{crewId}")
+	public BaseResponse<Void> modifyCrew(@Valid @RequestBody CrewRequestDTO crewDTO,
 		@PathVariable long crewId, @RequestHeader(name = "Uuid") String uuid) {
-		joinFormService.addJoinForm(joinFormDTO, crewId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.SUBMISSION_JOIN_FORM, null);
+		crewService.modifyCrew(crewDTO, crewId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.MODIFY_CREW, null);
 	}
 
-	@Operation(summary = "한 소모임의 가입 신청서 목록 조회", description = "한 소모임에 온 가입 신청서 목록을 조회한다.")
-	@GetMapping("/join-forms/{crewId}")
-	public BaseResponse<List<JoinFormListDTO>> getJoinForms(@PathVariable long crewId,
+	@Operation(summary = "소모임 강제 퇴장", description = "소모임에서 회원을 강제로 퇴장시킨다.(블랙리스트로 변경)")
+	@DeleteMapping("/forced-exit/{crewId}")
+	public BaseResponse<Void> forcedExitCrew(@Valid @RequestBody CrewOutDTO crewOutDTO,
+		@PathVariable long crewId,
 		@RequestHeader(name = "Uuid") String uuid) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_JOIN_FORM_LIST,
-			joinFormService.getJoinFormList(crewId, uuid));
+		crewService.forcedExitCrew(crewOutDTO, crewId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.FORCED_EXIT_CREW, null);
 	}
 
-	@Operation(summary = "소모임 가입 신청서 상세 조회", description = "소모임 가입 신청서를 상세 조회한다.")
-	@GetMapping("/join-form/{joinFormId}")
-	public BaseResponse<JoinFormResponseDTO> getJoinForm(@PathVariable String joinFormId) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_JOIN_FORM,
-			joinFormService.getJoinForm(joinFormId));
-	}
-
-	@Operation(summary = "소모임 가입 신청서 수락", description = "소모임 가입 신청서를 수락한다.")
-	@PostMapping("/acceptance/join/{joinFormId}")
-	public BaseResponse<Void> acceptJoinForm(@PathVariable String joinFormId,
-		@RequestHeader(name = "Uuid") String uuid) {
-		joinFormService.acceptJoinForm(joinFormId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.ACCEPT_JOIN_FORM, null);
-	}
-
-	@Operation(summary = "소모임 가입 신청서 거절", description = "소모임 가입 신청서를 거절한다.")
-	@DeleteMapping("/rejection/join/{joinFormId}")
-	public BaseResponse<Void> rejectJoinForm(@PathVariable String joinFormId,
-		@RequestHeader(name = "Uuid") String uuid) {
-		joinFormService.rejectJoinForm(joinFormId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.REJECT_JOIN_FORM, null);
-	}
-
-	@Operation(summary = "나의 소모임 가입신청서 리스트 조회", description = "나의 소모임 가입신청서 리스트를 조회한다.")
-	@GetMapping("/my-join-forms")
-	public BaseResponse<List<MyJoinFormDTO>> getMyJoinForms(
-		@RequestHeader(name = "Uuid") String uuid) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_MY_JOIN_FORM_LIST,
-			joinFormService.getMyJoinForms(uuid));
-	}
-
-	@Operation(summary = "소모임 가입 신청서 철회", description = "제출한 소모임 가입 신청서를 철회한다.")
-	@DeleteMapping("/cancellation/join/{joinFormId}")
-	public BaseResponse<Void> cancelJoinForm(@PathVariable String joinFormId,
-		@RequestHeader(name = "Uuid") String uuid) {
-		joinFormService.cancelJoinForm(joinFormId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.CANCEL_JOIN_FORM, null);
-	}
 }
 

--- a/src/main/java/hobbiedo/crew/presentation/CrewController.java
+++ b/src/main/java/hobbiedo/crew/presentation/CrewController.java
@@ -51,6 +51,14 @@ public class CrewController {
 		return BaseResponse.onSuccess(SuccessStatus.JOIN_FREE_CREW, null);
 	}
 
+	@Operation(summary = "취미와 활동 지역에 해당하는 소모임 정보 목록 조회", description = "취미와 활동 지역에 해당하는 소모임 정보 목록을 조회한다.(순서 랜덤)")
+	@GetMapping("/info/{hobbyId}/{regionId}")
+	public BaseResponse<List<CrewDetailDTO>> getCrewInfoList(@PathVariable long hobbyId,
+		@PathVariable long regionId) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_INFO_LIST,
+			crewService.getCrewInfoList(hobbyId, regionId));
+	}
+
 	@Operation(summary = "소모임 정보 조회", description = "소모임 ID를 통해 소모임 정보를 조회한다.")
 	@GetMapping("/{crewId}")
 	public BaseResponse<CrewDetailDTO> getCrewInfo(@PathVariable long crewId) {
@@ -58,8 +66,8 @@ public class CrewController {
 			crewService.getCrewInfo(crewId));
 	}
 
-	@Operation(summary = "취미와 활동 지역에 해당하는 소모임 아이디 조회", description = "취미와 활동 지역에 해당하는 소모임 아이디 리스트를 조회한다.(순서 랜덤)")
-	@GetMapping("/list/{hobbyId}/{regionId}")
+	@Operation(summary = "취미와 활동 지역에 해당하는 소모임 아이디 목록 조회", description = "취미와 활동 지역에 해당하는 소모임 아이디 목록을 조회한다.(순서 랜덤)")
+	@GetMapping("/id/{hobbyId}/{regionId}")
 	public BaseResponse<List<CrewIdDTO>> getCrewIdList(@PathVariable long hobbyId,
 		@PathVariable long regionId) {
 		return BaseResponse.onSuccess(SuccessStatus.FIND_CREWS_BY_HOBBY_AND_REGION,

--- a/src/main/java/hobbiedo/crew/presentation/JoinFormController.java
+++ b/src/main/java/hobbiedo/crew/presentation/JoinFormController.java
@@ -6,20 +6,16 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import hobbiedo.crew.application.CrewService;
-import hobbiedo.crew.dto.request.CrewOutDTO;
-import hobbiedo.crew.dto.request.CrewRequestDTO;
-import hobbiedo.crew.dto.response.CrewDetailDTO;
-import hobbiedo.crew.dto.response.CrewIdDTO;
-import hobbiedo.crew.dto.response.CrewNameDTO;
-import hobbiedo.crew.dto.response.CrewProfileDTO;
-import hobbiedo.crew.dto.response.CrewResponseDTO;
+import hobbiedo.crew.application.JoinFormService;
+import hobbiedo.crew.dto.request.JoinFormRequestDTO;
+import hobbiedo.crew.dto.response.JoinFormListDTO;
+import hobbiedo.crew.dto.response.JoinFormResponseDTO;
+import hobbiedo.crew.dto.response.MyJoinFormDTO;
 import hobbiedo.global.base.BaseResponse;
 import hobbiedo.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,85 +29,61 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v1/users/crew")
 public class JoinFormController {
 
-	private final CrewService crewService;
+	private final JoinFormService joinFormService;
 
-	@Operation(summary = "소모임 생성", description = "소모임을 생성한다.(대표 사진은 아예 안보내도 되고 해시태그는 []로, 있으면 5개까지 가능")
-	@PostMapping
-	public BaseResponse<CrewIdDTO> createCrew(@Valid @RequestBody CrewRequestDTO crewDTO,
-		@RequestHeader(name = "Uuid") String uuid) {
-		return BaseResponse.onSuccess(SuccessStatus.CREATE_CREW,
-			crewService.createCrew(crewDTO, uuid));
-	}
-
-	@Operation(summary = "(자유 방식) 소모임 가입", description = "자유 방식 소모임에 새로운 회원을 추가한다.")
-	@PostMapping("/join/{crewId}")
-	public BaseResponse<Void> joinFreeCrew(@PathVariable long crewId,
-		@RequestHeader(name = "Uuid") String uuid) {
-		crewService.joinCrew(crewId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.JOIN_FREE_CREW, null);
-	}
-
-	@Operation(summary = "소모임 정보 조회", description = "소모임 ID를 통해 소모임 정보를 조회한다.")
-	@GetMapping("/{crewId}")
-	public BaseResponse<CrewDetailDTO> getCrewInfo(@PathVariable long crewId) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_INFO,
-			crewService.getCrewInfo(crewId));
-	}
-
-	@Operation(summary = "취미와 활동 지역에 해당하는 소모임 아이디 조회", description = "취미와 활동 지역에 해당하는 소모임 아이디 리스트를 조회한다.(순서 랜덤)")
-	@GetMapping("/list/{hobbyId}/{regionId}")
-	public BaseResponse<List<CrewIdDTO>> getCrewIdList(@PathVariable long hobbyId,
-		@PathVariable long regionId) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_CREWS_BY_HOBBY_AND_REGION,
-			crewService.getCrewsByHobbyAndRegion(hobbyId, regionId));
-	}
-
-	@Operation(summary = "한 유저가 가입한 소모임 프로필 목록 조회", description = "한 유저가 가입한 소모임 프로필 목록을 조회한다.")
-	@GetMapping("/list/profile")
-	public BaseResponse<List<CrewProfileDTO>> getCrewProfileList(
-		@RequestHeader(name = "Uuid") String uuid) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_PROFILE_LIST,
-			crewService.getCrewProfiles(uuid));
-	}
-
-	@Operation(summary = "소모임 이름 조회", description = "소모임 ID를 통해 소모임 이름을 조회한다.")
-	@GetMapping("/name/{crewId}")
-	public BaseResponse<CrewNameDTO> getCrewName(@PathVariable long crewId) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_NAME,
-			crewService.getCrewName(crewId));
-	}
-
-	@Operation(summary = "소모임 탈퇴", description = "소모임에서 회원을 탈퇴시키고 소모임 인원을 -1 한다.")
-	@DeleteMapping("/withdrawal/{crewId}")
-	public BaseResponse<Void> withdrawalCrew(@PathVariable long crewId,
-		@RequestHeader(name = "Uuid") String uuid) {
-		crewService.deleteCrewMember(crewId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.WITHDRAWAL_CREW, null);
-	}
-
-	@Operation(summary = "소모임 정보 수정화면 조회", description = "소모임 정보 수정화면을 조회한다.")
-	@GetMapping("/modify-view/{crewId}")
-	public BaseResponse<CrewResponseDTO> getCrewModifyView(@PathVariable long crewId) {
-		return BaseResponse.onSuccess(SuccessStatus.FIND_CREW_MODIFY_VIEW,
-			crewService.getCrew(crewId));
-	}
-
-	@Operation(summary = "소모임 정보 수정", description = "소모임 정보를 수정한다.")
-	@PutMapping("/{crewId}")
-	public BaseResponse<Void> modifyCrew(@Valid @RequestBody CrewRequestDTO crewDTO,
+	@Operation(summary = "(가입 방식) 소모임 가입 신청서 제출", description = "가입 방식 소모임에 가입 신청서를 제출한다.")
+	@PostMapping("/submission/join-form/{crewId}")
+	public BaseResponse<Void> submissionJoinForm(@Valid @RequestBody JoinFormRequestDTO joinFormDTO,
 		@PathVariable long crewId, @RequestHeader(name = "Uuid") String uuid) {
-		crewService.modifyCrew(crewDTO, crewId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.MODIFY_CREW, null);
+		joinFormService.addJoinForm(joinFormDTO, crewId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.SUBMISSION_JOIN_FORM, null);
 	}
 
-	@Operation(summary = "소모임 강제 퇴장", description = "소모임에서 회원을 강제로 퇴장시킨다.(블랙리스트로 변경)")
-	@DeleteMapping("/forced-exit/{crewId}")
-	public BaseResponse<Void> forcedExitCrew(@Valid @RequestBody CrewOutDTO crewOutDTO,
-		@PathVariable long crewId,
+	@Operation(summary = "한 소모임의 가입 신청서 목록 조회", description = "한 소모임에 온 가입 신청서 목록을 조회한다.")
+	@GetMapping("/join-forms/{crewId}")
+	public BaseResponse<List<JoinFormListDTO>> getJoinForms(@PathVariable long crewId,
 		@RequestHeader(name = "Uuid") String uuid) {
-		crewService.forcedExitCrew(crewOutDTO, crewId, uuid);
-		return BaseResponse.onSuccess(SuccessStatus.FORCED_EXIT_CREW, null);
+		return BaseResponse.onSuccess(SuccessStatus.FIND_JOIN_FORM_LIST,
+			joinFormService.getJoinFormList(crewId, uuid));
 	}
 
+	@Operation(summary = "소모임 가입 신청서 상세 조회", description = "소모임 가입 신청서를 상세 조회한다.")
+	@GetMapping("/join-form/{joinFormId}")
+	public BaseResponse<JoinFormResponseDTO> getJoinForm(@PathVariable String joinFormId) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_JOIN_FORM,
+			joinFormService.getJoinForm(joinFormId));
+	}
+
+	@Operation(summary = "소모임 가입 신청서 수락", description = "소모임 가입 신청서를 수락한다.")
+	@PostMapping("/acceptance/join/{joinFormId}")
+	public BaseResponse<Void> acceptJoinForm(@PathVariable String joinFormId,
+		@RequestHeader(name = "Uuid") String uuid) {
+		joinFormService.acceptJoinForm(joinFormId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.ACCEPT_JOIN_FORM, null);
+	}
+
+	@Operation(summary = "소모임 가입 신청서 거절", description = "소모임 가입 신청서를 거절한다.")
+	@DeleteMapping("/rejection/join/{joinFormId}")
+	public BaseResponse<Void> rejectJoinForm(@PathVariable String joinFormId,
+		@RequestHeader(name = "Uuid") String uuid) {
+		joinFormService.rejectJoinForm(joinFormId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.REJECT_JOIN_FORM, null);
+	}
+
+	@Operation(summary = "나의 소모임 가입신청서 리스트 조회", description = "나의 소모임 가입신청서 리스트를 조회한다.")
+	@GetMapping("/my-join-forms")
+	public BaseResponse<List<MyJoinFormDTO>> getMyJoinForms(
+		@RequestHeader(name = "Uuid") String uuid) {
+		return BaseResponse.onSuccess(SuccessStatus.FIND_MY_JOIN_FORM_LIST,
+			joinFormService.getMyJoinForms(uuid));
+	}
+
+	@Operation(summary = "소모임 가입 신청서 철회", description = "제출한 소모임 가입 신청서를 철회한다.")
+	@DeleteMapping("/cancellation/join/{joinFormId}")
+	public BaseResponse<Void> cancelJoinForm(@PathVariable String joinFormId,
+		@RequestHeader(name = "Uuid") String uuid) {
+		joinFormService.cancelJoinForm(joinFormId, uuid);
+		return BaseResponse.onSuccess(SuccessStatus.CANCEL_JOIN_FORM, null);
+	}
 }
 

--- a/src/main/java/hobbiedo/global/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/status/SuccessStatus.java
@@ -26,7 +26,7 @@ public enum SuccessStatus { //메시지를 중앙에서 관리하는 것이 유�
 	CREATE_CREW("소모임 생성에 성공하였습니다."),
 	JOIN_FREE_CREW("자유 방식 소모임에 가입 완료되었습니다."),
 	FIND_CREW_INFO("소모임 정보 조회에 성공하였습니다."),
-	FIND_CREWS_BY_HOBBY_AND_REGION("취미와 활동 지역에 해당하는 소모임 목록 조회에 성공하였습니다."),
+	FIND_CREWS_BY_HOBBY_AND_REGION("취미와 활동 지역에 해당하는 소모임 아이디 목록 조회에 성공하였습니다."),
 	SUBMISSION_JOIN_FORM("소모임 가입 신청서 제출에 성공하였습니다."),
 	FIND_CREW_PROFILE_LIST("가입한 소모임 목록 조회 조회에 성공하였습니다."),
 	FIND_CREW_NAME("소모임 이름 조회에 성공하였습니다."),
@@ -39,7 +39,8 @@ public enum SuccessStatus { //메시지를 중앙에서 관리하는 것이 유�
 	ACCEPT_JOIN_FORM("가입 신청서 수락에 성공하였습니다."),
 	REJECT_JOIN_FORM("가입 신청서 거절에 성공하였습니다."),
 	FIND_MY_JOIN_FORM_LIST("나의 소모임 가입 신청서 목록 조회에 성공하였습니다."),
-	CANCEL_JOIN_FORM("가입 신청서 철회에 성공하였습니다."),;
+	CANCEL_JOIN_FORM("가입 신청서 철회에 성공하였습니다."),
+	FIND_CREW_INFO_LIST("취미와 활동 지역에 해당하는 소모임 정보 목록 조회에 성공하였습니다."),;
 
 	private final String status;
 }


### PR DESCRIPTION
## 📣 취미와 활동 지역에 해당하는 소모임 정보 목록 조회 api 병합
### 📅 2024.06.21

### 🌵Branch
feature/crew → develop

### 📢 Description
nav1의 소모임 둘러보기에서 취미와 지역에 속하는 crewId 조회 api 와 crewId로 소모임 정보 조회 api 를 나눠눴다가 
한 api 로 병합

### 💬Issue Number
[#17 ] - 💫[FEAT] 소모임 기능 중 nav 2,4,5 api 구현

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
