### PR TITLE
[refactor] 소모임 정보 수정 시, regionId 와 hobbyId 제거

### DIFF
--- a/src/main/java/hobbiedo/crew/application/CrewServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/CrewServiceImp.java
@@ -22,7 +22,7 @@ import hobbiedo.crew.infrastructure.jpa.CrewMemberRepository;
 import hobbiedo.crew.infrastructure.jpa.CrewRepository;
 import hobbiedo.crew.infrastructure.jpa.HashTagRepository;
 import hobbiedo.crew.kafka.application.KafkaProducerService;
-import hobbiedo.crew.kafka.dto.ChatEntryExitDTO;
+import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
 import hobbiedo.crew.kafka.dto.CrewScoreDTO;
 import hobbiedo.crew.kafka.type.EntryExitType;
 import hobbiedo.global.exception.GlobalException;
@@ -56,7 +56,7 @@ public class CrewServiceImp implements CrewService {
 		createHashTag(crew, crewDTO.getHashTagList());
 		// ChatLastStatus 생성 및 입장 chat 전송
 		kafkaProducerService.setCreateCrewTopic(
-			ChatEntryExitDTO.toDto(crew.getId(), uuid, EntryExitType.ENTRY));
+			CrewEntryExitDTO.toDto(crew.getId(), uuid, EntryExitType.ENTRY));
 
 		return CrewIdDTO.toDto(crew.getId());
 	}
@@ -94,7 +94,7 @@ public class CrewServiceImp implements CrewService {
 		changeCrewParticipant(crew, 1);
 		// ChatLastStatus 생성 맟 입장 chat 전송
 		kafkaProducerService.setJoinCrewTopic(
-			ChatEntryExitDTO.toDto(crew.getId(), uuid, EntryExitType.ENTRY));
+			CrewEntryExitDTO.toDto(crew.getId(), uuid, EntryExitType.ENTRY));
 	}
 
 	@Transactional
@@ -202,7 +202,7 @@ public class CrewServiceImp implements CrewService {
 		changeCrewParticipant(crewMember.getCrew(), -1);
 		// 퇴장 chat 전송
 		kafkaProducerService.setExitCrewTopic(
-			ChatEntryExitDTO.toDto(crewId, uuid, EntryExitType.EXIT));
+			CrewEntryExitDTO.toDto(crewId, uuid, EntryExitType.EXIT));
 	}
 
 	@Override
@@ -240,7 +240,7 @@ public class CrewServiceImp implements CrewService {
 		changeCrewParticipant(crewMember.getCrew(), -1);
 		// 강제 퇴장 chat 전송
 		kafkaProducerService.setForceExitCrewTopic(
-			ChatEntryExitDTO.toDto(crewId, crewOutDTO.getOutUuid(), EntryExitType.FORCE_EXIT));
+			CrewEntryExitDTO.toDto(crewId, crewOutDTO.getOutUuid(), EntryExitType.FORCE_EXIT));
 	}
 
 	@Transactional

--- a/src/main/java/hobbiedo/crew/kafka/application/KafkaProducerService.java
+++ b/src/main/java/hobbiedo/crew/kafka/application/KafkaProducerService.java
@@ -3,7 +3,7 @@ package hobbiedo.crew.kafka.application;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
-import hobbiedo.crew.kafka.dto.ChatEntryExitDTO;
+import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
 import hobbiedo.global.exception.GlobalException;
 import hobbiedo.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class KafkaProducerService {
 	private static final String EXIT_CREW_TOPIC = "exit-crew-topic";
 	private static final String FORCE_EXIT_CREW_TOPIC = "force-exit-crew-topic";
 
-	public void setCreateCrewTopic(ChatEntryExitDTO eventDto) {
+	public void setCreateCrewTopic(CrewEntryExitDTO eventDto) {
 		try {
 
 			kafkaTemplate.send(CREATE_CREW_TOPIC, eventDto);
@@ -32,7 +32,7 @@ public class KafkaProducerService {
 		}
 	}
 
-	public void setJoinCrewTopic(ChatEntryExitDTO eventDto) {
+	public void setJoinCrewTopic(CrewEntryExitDTO eventDto) {
 		try {
 
 			kafkaTemplate.send(JOIN_CREW_TOPIC, eventDto);
@@ -44,7 +44,7 @@ public class KafkaProducerService {
 		}
 	}
 
-	public void setExitCrewTopic(ChatEntryExitDTO eventDto) {
+	public void setExitCrewTopic(CrewEntryExitDTO eventDto) {
 		try {
 
 			kafkaTemplate.send(EXIT_CREW_TOPIC, eventDto);
@@ -56,7 +56,7 @@ public class KafkaProducerService {
 		}
 	}
 
-	public void setForceExitCrewTopic(ChatEntryExitDTO eventDto) {
+	public void setForceExitCrewTopic(CrewEntryExitDTO eventDto) {
 		try {
 
 			kafkaTemplate.send(FORCE_EXIT_CREW_TOPIC, eventDto);

--- a/src/main/java/hobbiedo/crew/kafka/dto/CrewEntryExitDTO.java
+++ b/src/main/java/hobbiedo/crew/kafka/dto/CrewEntryExitDTO.java
@@ -10,13 +10,13 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatEntryExitDTO {
+public class CrewEntryExitDTO {
 	private long crewId;
 	private String uuid;
 	private EntryExitType entryExitType;
 
-	public static ChatEntryExitDTO toDto(long crewId, String uuid, EntryExitType entryExitType) {
-		return ChatEntryExitDTO.builder()
+	public static CrewEntryExitDTO toDto(long crewId, String uuid, EntryExitType entryExitType) {
+		return CrewEntryExitDTO.builder()
 			.crewId(crewId)
 			.uuid(uuid)
 			.entryExitType(entryExitType)


### PR DESCRIPTION
## 📣 소모임 정보 수정 시, regionId 와 hobbyId 제거
### 📅 2024.06.23

### 🌵Branch
feature/refactor-modify-crew → develop

### 📢 Description
- 소모임 정보 수정 시, response 값에서 regionId 와 hobbyId 제거, 수정은 name도 제거
- 소모임 강제 퇴장 시, 데이터 삭제가 없으니 DeleteMapping 에서 PostMapping 으로 변경

### 💬Issue Number
[#17 ] - [FEAT] 소모임 기능 중 nav 2,4,5 api 구현 

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
